### PR TITLE
RepositoryOptions prevent duplicate registrations

### DIFF
--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/CompositionRoot.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/CompositionRoot.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace DfE.Data.ComponentLibrary.Infrastructure.Persistence.CosmosDb;
 
@@ -30,10 +31,14 @@ public static class CompositionRoot
         }
 
         // Configure repository options using the application configuration.
-        services.AddOptions<RepositoryOptions>()
-            .Configure<IConfiguration>(
-                (settings, configuration) =>
-                    configuration.GetSection(nameof(RepositoryOptions)).Bind(settings));
+        if (!services.Any(
+                (service) => service.ServiceType == typeof(IConfigureOptions<RepositoryOptions>)))
+        {
+            services.AddOptions<RepositoryOptions>()
+                .Configure<IConfiguration>(
+                    (settings, configuration) =>
+                        configuration.GetSection(nameof(RepositoryOptions)).Bind(settings));
+        }
 
         // Register Cosmos DB providers and repositories as singleton services.
         services.TryAddSingleton<ICosmosDbClientProvider, CosmosDbClientProvider>(); // Provides Cosmos DB client instance

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.csproj
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.csproj
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
 	<Version>$(VERSION)</Version>
-	<AssemblyVersion>1.0.0</AssemblyVersion>
+	<AssemblyVersion>$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH).0</AssemblyVersion>
 	<FileVersion>$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH).0</FileVersion>
 	<InformationalVersion>$(VERSION)-$(ShortSha)</InformationalVersion>
   </PropertyGroup>

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.csproj
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.csproj
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
 	<Version>$(VERSION)</Version>
-	<AssemblyVersion>$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH).0</AssemblyVersion>
+	<AssemblyVersion>1.0.0</AssemblyVersion>
 	<FileVersion>$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH).0</FileVersion>
 	<InformationalVersion>$(VERSION)-$(ShortSha)</InformationalVersion>
   </PropertyGroup>

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/CompositionRootTests.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/CompositionRootTests.cs
@@ -1,0 +1,28 @@
+﻿using Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.Options;
+using DfE.Data.ComponentLibrary.Infrastructure.Persistence.CosmosDb;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.Tests.Unit;
+
+public sealed class CompositionRootTests
+{
+
+    [Fact]
+    public void AddCosmosDbDependencies_Registers_RepositoryOptions_OnlyOnce_When_CalledMultipleTimes()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddCosmosDbDependencies();
+        services.AddCosmosDbDependencies();
+
+        // Assert
+        int repositoryOptionsRegistrationCount = services
+            .Count(sd => sd.ServiceType == typeof(IConfigureOptions<RepositoryOptions>));
+
+        Assert.Equal(1, repositoryOptionsRegistrationCount);
+    }
+
+}


### PR DESCRIPTION
## Summary

When [`AddCosmosDbDependencies`](https://github.com/DFE-Digital/infrastructure-persistence-cosmosdb/pull/4/files#diff-a29a9ddc741a69739aec83486a27212cee6920bf64bd2a4f493fa8d0a9f7c577L24) is called multiple times from the consumer, it registers 2 instances of `IConfigureOptions<RepositoryOptions>` in the provided `IServiceCollection`. 

While this is a bug on the consumer side, it would be preferrable to avoid this.

We do also use `TryAdd` for the other registrations to prevent duplicates

While this also iterates through the `IServiceCollection`, it should only occur once, at startup.