### PR TITLE
feat: BREAKING Flatten RepositoryOptions from List<Dictionary> to Dictionary

### DIFF
--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Options/Extensions/RepositoryOptionsExtensions.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Options/Extensions/RepositoryOptionsExtensions.cs
@@ -18,33 +18,14 @@ public static class RepositoryOptionsExtensions
         this RepositoryOptions repositoryOptions, string containerKey)
     {
         // Attempt to retrieve the container options dictionary and fetch the requested container.
-        _ = TryGetContainerOptionsDictionary(repositoryOptions, containerKey)
-            .TryGetValue(containerKey, out var container);
 
-        // Validate if the container was found.
-        if (container == null)
+        ArgumentNullException.ThrowIfNull(repositoryOptions.Containers);
+        if(!repositoryOptions.Containers.TryGetValue(containerKey, out ContainerOptions? containerOptions))
         {
             throw new InvalidOperationException(
                 $"Container dictionary options with container key: {containerKey} not configured in options.");
         }
 
-        return container;
+        return containerOptions;
     }
-
-    /// <summary>
-    /// Retrieves the dictionary of container options from the repository configurations.
-    /// </summary>
-    /// <param name="repositoryOptions">The repository options containing container configurations.</param>
-    /// <param name="containerKey">The key identifying the container.</param>
-    /// <returns>A dictionary containing container configurations.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if no container is found for the given key.
-    /// </exception>
-    public static Dictionary<string, ContainerOptions> TryGetContainerOptionsDictionary(
-        this RepositoryOptions repositoryOptions, string containerKey) =>
-            repositoryOptions.Containers?
-                .SingleOrDefault(containerOptionsDict =>
-                    containerOptionsDict.ContainsKey(containerKey)) ??
-                    throw new InvalidOperationException(
-                        $"Container with key: {containerKey} not configured in options.");
 }

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Options/RepositoryOptions.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Options/RepositoryOptions.cs
@@ -37,5 +37,5 @@ public sealed class RepositoryOptions
     /// Represents a collection of container configurations.
     /// </summary>
     [JsonProperty(nameof(Containers))]
-    public List<Dictionary<string, ContainerOptions>>? Containers { get; set; }
+    public Dictionary<string, ContainerOptions>? Containers { get; set; }
 }

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Integration/Fixture/CosmosDbConfigurationStub.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Integration/Fixture/CosmosDbConfigurationStub.cs
@@ -36,7 +36,7 @@ public static class CosmosDbConfigurationStub
             { "RepositoryOptions:PrimaryKey", PrimaryKey },
             { "RepositoryOptions:DatabaseId", DatabaseId },
             { "RepositoryOptions:ConnectionMode", "1" },
-            { $"RepositoryOptions:Containers:0:{containerName}:ContainerName", containerName },
-            { $"RepositoryOptions:Containers:0:{containerName}:PartitionKey", PartitionKey }
+            { $"RepositoryOptions:Containers:{containerName}:ContainerName", containerName },
+            { $"RepositoryOptions:Containers:{containerName}:PartitionKey", PartitionKey }
         };
 }

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/Options/Extensions/RepositoryOptionsExtensionsTests.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/Options/Extensions/RepositoryOptionsExtensionsTests.cs
@@ -6,6 +6,22 @@ namespace Dfe.Data.Common.Infrastructure.Persistence.CosmosDb.Tests.Unit.Options
 public class RepositoryOptionsExtensionsTests
 {
     [Fact]
+    public void GetContainerOptions_Should_ThrowNull_When_ContainersIsNull()
+    {
+        // Arrange
+        var repositoryOptions = new RepositoryOptions
+        {
+            Containers = null
+        };
+
+        const string containerKey = "TestContainer";
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            repositoryOptions.GetContainerOptions(containerKey));
+    }
+
+    [Fact]
     public void GetContainerOptions_ShouldReturnContainerOptions_WhenContainerExists()
     {
         // Arrange
@@ -15,11 +31,10 @@ public class RepositoryOptionsExtensionsTests
 
         var repositoryOptions = new RepositoryOptions
         {
-            Containers = [
-                new Dictionary<string, ContainerOptions>{
+            Containers = new Dictionary<string, ContainerOptions>{
                     { containerKey, expectedContainerOptions }
                 }
-            ]
+
         };
 
         // Act
@@ -37,7 +52,7 @@ public class RepositoryOptionsExtensionsTests
         // Arrange
         var repositoryOptions = new RepositoryOptions
         {
-            Containers = [
+            Containers = 
                 new Dictionary<string, ContainerOptions> {
                     { "ExistingContainer",
                         new ContainerOptions {
@@ -45,7 +60,6 @@ public class RepositoryOptionsExtensionsTests
                         }
                     }
                 }
-            ]
         };
 
         const string missingContainerKey = "MissingContainer";
@@ -54,48 +68,6 @@ public class RepositoryOptionsExtensionsTests
         var exception = Assert.Throws<InvalidOperationException>(() =>
             repositoryOptions.GetContainerOptions(missingContainerKey));
 
-        Assert.Contains($"Container with key: {missingContainerKey} not configured in options.", exception.Message);
-    }
-
-    [Fact]
-    public void TryGetContainerOptionsDictionary_ShouldReturnContainerDictionary_WhenContainerExists()
-    {
-        // Arrange
-        const string containerKey = "TestContainer";
-        var expectedContainerOptions = new Dictionary<string, ContainerOptions>
-        {
-            { containerKey, new ContainerOptions { ContainerName = "TestContainer", PartitionKey = "/id" } }
-        };
-
-        var repositoryOptions = new RepositoryOptions
-        {
-            Containers = [expectedContainerOptions]
-        };
-
-        // Act
-        var result = repositoryOptions.TryGetContainerOptionsDictionary(containerKey);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.True(result.ContainsKey(containerKey));
-    }
-
-    [Fact]
-    public void TryGetContainerOptionsDictionary_ShouldThrowInvalidOperationException_WhenContainerDoesNotExist()
-    {
-        // Arrange
-        var repositoryOptions = new RepositoryOptions
-        {
-            Containers = []
-        };
-
-        const string missingContainerKey = "MissingContainer";
-
-        // Act & Assert
-        var exception =
-            Assert.Throws<InvalidOperationException>(() =>
-                repositoryOptions.TryGetContainerOptionsDictionary(missingContainerKey));
-
-        Assert.Contains($"Container with key: {missingContainerKey} not configured in options.", exception.Message);
+        Assert.Contains($"Container dictionary options with container key: {missingContainerKey} not configured in options.", exception.Message);
     }
 }

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/Providers/TestDoubles/RepositoryOptionsTestDouble.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/Providers/TestDoubles/RepositoryOptionsTestDouble.cs
@@ -39,9 +39,10 @@ internal class RepositoryOptionsTestDouble
     /// <param name="partitionKey">The partition key for the container.</param>
     /// <returns>A RepositoryOptions object with the specified container and partition key.</returns>
     public static RepositoryOptions CreateRepositoryOptionsStub(string containerName, string partitionKey) =>
-        new(){
+        new()
+        {
             // Initializing the Containers property with a list of dictionaries
-            Containers = [
+            Containers =
                 // Adding a dictionary with the container name as the key and ContainerOptions as the value
                 new Dictionary<string, ContainerOptions> {
                     { containerName,
@@ -51,6 +52,5 @@ internal class RepositoryOptionsTestDouble
                         }
                     }
                 }
-            ]
         };
 }

--- a/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/Providers/TestDoubles/RepositoryOptionsTestDouble.cs
+++ b/Dfe.Dfe.Data.Common.Infrastructure.Persistence.CosmosDb/Tests/Unit/Providers/TestDoubles/RepositoryOptionsTestDouble.cs
@@ -41,7 +41,7 @@ internal class RepositoryOptionsTestDouble
     public static RepositoryOptions CreateRepositoryOptionsStub(string containerName, string partitionKey) =>
         new()
         {
-            // Initializing the Containers property with a list of dictionaries
+            // Initializing the Containers property with a Dictionary
             Containers =
                 // Adding a dictionary with the container name as the key and ContainerOptions as the value
                 new Dictionary<string, ContainerOptions> {


### PR DESCRIPTION
Note: This is breaking change, hence incrementing `tag` for major version will be necessary.

Previously `RepositoryOptions` was bound from Configuration in shape below;

```json
 "RepositoryOptions": {
        "Containers": [
            {
                "application-data": {
                    "ContainerName": "application-data",
                    "PartitionKey": "/DOCTYPE"
                }
            },
            {
                "further-education": {
                    "ContainerName": "further-education-v2",
                    "PartitionKey": "/ULN"
                }
            }
        ]
    },
```

There's no clear reason why `Containers` is a List<Dictionary> and not a Dictionary to enable directly Keying into a paticular `ContainerOptions`. 

We don't expect multiple `ContainerOptions` to be stored in an entry of the List like below e.g

```json
    {
                "container-1": {
                    "ContainerName": "container-1",
                    "PartitionKey": "/DOCTYPE"
                },
                "container-2": {
                    "ContainerName": "container-2",
                    "PartitionKey": "/id"
                }
    },
```

After raising to @spanersoraferty in agreement to flatten off so that `infrastructure-cognitive-search` can follow same pattern `SearchIndexOptions`.